### PR TITLE
fix(config): fall back to global craft-config.yml

### DIFF
--- a/hooks/lib/config.sh
+++ b/hooks/lib/config.sh
@@ -3,8 +3,8 @@
 # Config Resolution Library
 # Resolves configuration from multiple sources with priority:
 #   1. .craft-config.yml in $PWD (highest)
-#   2. .craft-config.yml in ~/.claude (global, shared across projects)
-#   3. CLAUDE_PLUGIN_OPTION_* env vars
+#   2. CLAUDE_PLUGIN_OPTION_* env vars (explicit plugin config, can be project-scoped)
+#   3. .craft-config.yml in ~/.claude (global, shared across projects)
 #   4. Hardcoded defaults (lowest)
 #
 # Usage:
@@ -31,10 +31,6 @@ _config_resolve() {
         yml_value=$(_config_parse_yml_value "$key" "$PWD/.craft-config.yml")
     fi
 
-    if [[ -z "$yml_value" ]] && [[ -f "${HOME}/.claude/.craft-config.yml" ]]; then
-        yml_value=$(_config_parse_yml_value "$key" "${HOME}/.claude/.craft-config.yml")
-    fi
-
     if [[ -n "$yml_value" ]]; then
         echo "$yml_value"
         return 0
@@ -44,6 +40,14 @@ _config_resolve() {
     if [[ -n "${!env_var:-}" ]]; then
         echo "${!env_var}"
         return 0
+    fi
+
+    if [[ -f "${HOME}/.claude/.craft-config.yml" ]]; then
+        yml_value=$(_config_parse_yml_value "$key" "${HOME}/.claude/.craft-config.yml")
+        if [[ -n "$yml_value" ]]; then
+            echo "$yml_value"
+            return 0
+        fi
     fi
 
     echo "$default"

--- a/hooks/lib/config.sh
+++ b/hooks/lib/config.sh
@@ -3,8 +3,9 @@
 # Config Resolution Library
 # Resolves configuration from multiple sources with priority:
 #   1. .craft-config.yml in $PWD (highest)
-#   2. CLAUDE_PLUGIN_OPTION_* env vars
-#   3. Hardcoded defaults (lowest)
+#   2. .craft-config.yml in ~/.claude (global, shared across projects)
+#   3. CLAUDE_PLUGIN_OPTION_* env vars
+#   4. Hardcoded defaults (lowest)
 #
 # Usage:
 #   source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/config.sh"
@@ -28,6 +29,10 @@ _config_resolve() {
     local yml_value=""
     if [[ -f "$PWD/.craft-config.yml" ]]; then
         yml_value=$(_config_parse_yml_value "$key" "$PWD/.craft-config.yml")
+    fi
+
+    if [[ -z "$yml_value" ]] && [[ -f "${HOME}/.claude/.craft-config.yml" ]]; then
+        yml_value=$(_config_parse_yml_value "$key" "${HOME}/.claude/.craft-config.yml")
     fi
 
     if [[ -n "$yml_value" ]]; then

--- a/tests/core/test-config.sh
+++ b/tests/core/test-config.sh
@@ -17,6 +17,12 @@ mkdir -p "$TEST_DIR"
 ORIGINAL_PWD="$PWD"
 cd "$TEST_DIR"
 
+# Sandbox HOME so a developer's real ~/.claude/.craft-config.yml can never
+# leak into these tests (config.sh reads ${HOME}/.claude/.craft-config.yml)
+ORIGINAL_HOME="$HOME"
+export HOME="$TEST_DIR/home"
+mkdir -p "$HOME/.claude"
+
 # Clean env before each test section
 unset CLAUDE_PLUGIN_OPTION_strictness 2>/dev/null || true
 unset CLAUDE_PLUGIN_OPTION_stack 2>/dev/null || true
@@ -103,6 +109,72 @@ else
 fi
 
 rm -f "$TEST_DIR/.craft-config.yml"
+unset CLAUDE_PLUGIN_OPTION_strictness 2>/dev/null || true
+unset CLAUDE_PLUGIN_OPTION_stack 2>/dev/null || true
+
+# =============================================================================
+# 3b. Global config fallback (~/.claude/.craft-config.yml)
+# =============================================================================
+echo ""
+echo "=== Global Config Fallback ==="
+
+GLOBAL_CONFIG="$HOME/.claude/.craft-config.yml"
+
+# Global-only value resolves (no PWD file, no env var)
+rm -f "$TEST_DIR/.craft-config.yml"
+unset CLAUDE_PLUGIN_OPTION_strictness 2>/dev/null || true
+unset CLAUDE_PLUGIN_OPTION_stack 2>/dev/null || true
+
+cat > "$GLOBAL_CONFIG" <<'YAML'
+strictness: moderate
+stack: symfony
+YAML
+
+result=$(config_strictness)
+if [[ "$result" == "moderate" ]]; then
+    log_pass "Global config strictness applies when nothing else is set"
+else
+    log_fail "Global config strictness should apply" "got '$result', expected 'moderate'"
+fi
+
+result=$(config_stack)
+if [[ "$result" == "symfony" ]]; then
+    log_pass "Global config stack applies when nothing else is set"
+else
+    log_fail "Global config stack should apply" "got '$result', expected 'symfony'"
+fi
+
+# Env var overrides global config (explicit plugin config wins)
+export CLAUDE_PLUGIN_OPTION_strictness="relaxed"
+
+result=$(config_strictness)
+if [[ "$result" == "relaxed" ]]; then
+    log_pass "Env var overrides global config"
+else
+    log_fail "Env var should override global config" "got '$result', expected 'relaxed'"
+fi
+
+# PWD config overrides global config
+cat > "$TEST_DIR/.craft-config.yml" <<'YAML'
+strictness: strict
+YAML
+
+result=$(config_strictness)
+if [[ "$result" == "strict" ]]; then
+    log_pass "PWD config overrides global config and env var"
+else
+    log_fail "PWD config should override global config" "got '$result', expected 'strict'"
+fi
+
+# Global fills only the keys the higher sources leave unset
+result=$(config_stack)
+if [[ "$result" == "symfony" ]]; then
+    log_pass "Global config fills keys missing from PWD config"
+else
+    log_fail "Global config should fill missing keys" "got '$result', expected 'symfony'"
+fi
+
+rm -f "$TEST_DIR/.craft-config.yml" "$GLOBAL_CONFIG"
 unset CLAUDE_PLUGIN_OPTION_strictness 2>/dev/null || true
 unset CLAUDE_PLUGIN_OPTION_stack 2>/dev/null || true
 
@@ -422,6 +494,7 @@ unset CLAUDE_PLUGIN_OPTION_sentry_project 2>/dev/null || true
 # Cleanup
 # =============================================================================
 cd "$ORIGINAL_PWD"
+export HOME="$ORIGINAL_HOME"
 unset CLAUDE_PLUGIN_OPTION_strictness 2>/dev/null || true
 unset CLAUDE_PLUGIN_OPTION_stack 2>/dev/null || true
 unset CLAUDE_PLUGIN_OPTION_sentry_org 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `_config_resolve()` only read `.craft-config.yml` from `$PWD`, silently ignoring the global config written by `/craftsman:setup` at `~/.claude/.craft-config.yml`.
- This broke config sharing across projects: settings configured globally via setup were never applied unless a per-project file also existed.
- Adds a check of `${HOME}/.claude/.craft-config.yml` between the PWD file check and the `CLAUDE_PLUGIN_OPTION_*` env var fallback.
- New priority order: 1. PWD file, 2. global file (`~/.claude/.craft-config.yml`), 3. env var, 4. default.

## Test plan
- Verified via manual sourcing of config.sh with a global-only value resolving correctly.