### PR TITLE
feat(hooks): add Spanish bias patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Opus rates to write a commit message.
 1. **Rules Engine with 3-Level Inheritance** - Global → Project → Directory overrides. Short form (`PHP001: warn`) or long form (custom regex rules). Legacy code coexists with strict new code via directory-level relaxation.
 2. **Structural Ratchet** - a committed baseline records each file's structural high-water mark (complexity, size, longest function, import fan-out, suppression count). A file you touch may improve or stay equal, never regress: the mark tightens automatically on a green pass and only loosens through a documented, counted suppression. Untouched legacy is never punished for debt it already had.
 3. **Adversarial Design Panel** - three contradictors (YAGNI, invariants and boundaries, feasibility) attack a design during `/craftsman:design`, before any code exists. Every objection lands in a retained or dismissed table: silence is not an option. Contradicting a design costs far less than contradicting the code built on it.
-4. **Cognitive Bias Detector** - real-time detection of acceleration bias, scope creep, and over-optimization in your prompts, bilingual FR/EN, context-aware to reduce false positives.
+4. **Cognitive Bias Detector** - real-time detection of acceleration bias, scope creep, and over-optimization in your prompts, trilingual FR/EN/ES, context-aware to reduce false positives.
 5. **Real-Time Quality Gate** - progressive validation on every Write/Edit: regex (<50ms, always on) → LSP semantics (live, via the official LSP plugin for your language) → static analysis and architecture (PHPStan/ESLint/deptrac, opt-in per machine because running a project's analysers runs its code, see [SECURITY.md](SECURITY.md)). Degrades gracefully with zero tools installed.
 6. **Metrics & Trend Analysis** - SQLite-backed tracking of violations, corrections, and sessions, with 7-day/30-day trend views to identify your most-violated rules.
 7. **Security Rules** - SEC001-003 (hardcoded secrets, dynamic eval, SQL by concatenation) verified in hooks and CI, with their doctrine routed to Claude on block. Setup observes the repository and asks at most four plain-language questions.
@@ -257,7 +257,7 @@ auto-commit; commands are explicitly invoked, never auto-triggered; methodology
 is opinionated (DDD/Clean Architecture).
 
 **Current constraints:** PHP/TypeScript get full rule coverage, other languages
-basic support only; bias detection patterns are EN/FR only; metrics are
+basic support only; bias detection patterns are EN/FR/ES only; metrics are
 per-machine, not shared across a team; auto-fixing violations and IDE plugins
 are not supported by design.
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -337,9 +337,9 @@ The `bias-detector.sh` hook (UserPromptSubmit) detects cognitive biases in your 
 
 | Bias | Trigger Keywords | Warning |
 |------|-----------------|---------|
-| Acceleration | "vite", "quick", "just do it" | STOP - Design first |
-| Scope Creep | "et aussi", "while we're at it" | STOP - Is this in scope? |
-| Over-Optimization | "abstraire", "generalize" | STOP - YAGNI |
+| Acceleration | "vite", "quick", "hazlo rápido" | STOP - Design first |
+| Scope Creep | "et aussi", "while we're at it", "y además agrega" | STOP - Is this in scope? |
+| Over-Optimization | "abstraire", "generalize", "hazlo configurable" | STOP - YAGNI |
 
 Bias detection is **warning-only** (exit 0) - it never blocks your workflow.
 

--- a/hooks/bias-detector.sh
+++ b/hooks/bias-detector.sh
@@ -26,26 +26,27 @@ fi
 [[ -z "$PROMPT" ]] && exit 0
 
 # =============================================================================
-# Bias Patterns (case-insensitive, bilingual FR/EN)
+# Bias Patterns (case-insensitive, trilingual FR/EN/ES)
 # =============================================================================
 
 # Acceleration bias: rushing without thinking
 # Context-aware: requires imperative verb context or explicit rush indicators
 # Reduced false positives: "quick fix" alone won't trigger, "just do it quick" will
-ACCELERATION_PATTERNS="(fais.{0,10}vite|code direct|pas le temps|no time|just do it|skip the (design|test|review)|hurry up|asap|do it now|juste code|sans (réfléchir|tester|design))"
+ACCELERATION_PATTERNS="(fais.{0,10}vite|code direct|pas le temps|no time|just do it|skip the (design|test|review)|hurry up|asap|do it now|juste code|sans (réfléchir|tester|design)|hazlo (ya|ahora|rápido)|no hay tiempo|omite (el )?(diseño|test|pruebas|revisión)|(hazlo|programa|implementa) sin (pensar|probar|diseñar))"
 
 # Scope creep: adding features beyond scope
 # Context-aware: requires action verb + addition pattern
-SCOPE_CREEP_PATTERNS="(et (aussi|en plus) (ajoute|fais|met|ajoutons)|tant qu'on y est|while we're at it.*(add|change|also)|also add|let's also (add|do|change)|and also (add|do|implement)|ajoutons aussi|rajoute)"
+SCOPE_CREEP_PATTERNS="(et (aussi|en plus) (ajoute|fais|met|ajoutons)|tant qu'on y est|while we're at it.*(add|change|also)|also add|let's also (add|do|change)|and also (add|do|implement)|ajoutons aussi|rajoute|y (también|además) (añade|agrega|implementa|cambia|haz)|ya que estamos.*(añade|agrega|implementa|cambia|haz)|agrega también)"
 
 # Over-optimization: premature abstraction
 # Context-aware: requires explicit generalization intent
-OVER_OPT_PATTERNS="(abstraire|généraliser|make it (abstract|configurable|generic|extensible)|future[- ]proof|pour (le futur|plus tard)|rends[- ]?(le )?(configurable|générique|abstrait))"
+OVER_OPT_PATTERNS="(abstraire|généraliser|make it (abstract|configurable|generic|extensible)|future[- ]proof|pour (le futur|plus tard)|rends[- ]?(le )?(configurable|générique|abstrait)|(abstrae|generaliza) (esto|este|esta|el|la)|vamos a (abstraer|generalizar)|hazlo (abstracto|configurable|genérico|extensible))"
 
 # Workflow enforcement: domain modeling without /craftsman:design
 # FR: crée une entité|value object|agrégat
 # EN: create entity|value object|aggregate
-DOMAIN_MODELING_PATTERNS="(create (a |an |the )?(entity|value object|aggregate|domain event|domain service)|crée (une |un |l'?)?(entité|value object|agrégat|événement de domaine))"
+# ES: crea una entidad|objeto de valor|agregado
+DOMAIN_MODELING_PATTERNS="(create (a |an |the )?(entity|value object|aggregate|domain event|domain service)|crée (une |un |l'?)?(entité|value object|agrégat|événement de domaine)|crea (una |un |la |el )?(entidad|objeto de valor|agregado|evento de dominio|servicio de dominio))"
 
 # =============================================================================
 # Detection & Warnings

--- a/tests/core/test-bias-detector.sh
+++ b/tests/core/test-bias-detector.sh
@@ -51,6 +51,15 @@ else
     log_fail "EN 'just do it quick' should detect acceleration" "exit=$exit_code"
 fi
 
+result=$(run_bias "hazlo rápido, no hay tiempo")
+exit_code="${result%%|*}"
+output="${result#*|}"
+if [[ "$exit_code" == "0" ]] && echo "$output" | grep -qi "Acceleration"; then
+    log_pass "ES 'hazlo rápido' detects acceleration bias"
+else
+    log_fail "ES 'hazlo rápido' should detect acceleration" "exit=$exit_code"
+fi
+
 # =============================================================================
 # Scope Creep Detection
 # =============================================================================
@@ -75,6 +84,15 @@ else
     log_fail "EN 'let's also add' should detect scope creep" "exit=$exit_code"
 fi
 
+result=$(run_bias "y además agrega registros")
+exit_code="${result%%|*}"
+output="${result#*|}"
+if [[ "$exit_code" == "0" ]] && echo "$output" | grep -qi "Scope Creep"; then
+    log_pass "ES 'y además agrega' detects scope creep"
+else
+    log_fail "ES 'y además agrega' should detect scope creep" "exit=$exit_code"
+fi
+
 # =============================================================================
 # Over-Optimization Detection
 # =============================================================================
@@ -90,6 +108,15 @@ else
     log_fail "FR 'abstraire ce pattern' should detect over-optimization" "exit=$exit_code"
 fi
 
+result=$(run_bias "hazlo configurable para el futuro")
+exit_code="${result%%|*}"
+output="${result#*|}"
+if [[ "$exit_code" == "0" ]] && echo "$output" | grep -qi "Over-Optimization"; then
+    log_pass "ES 'hazlo configurable' detects over-optimization"
+else
+    log_fail "ES 'hazlo configurable' should detect over-optimization" "exit=$exit_code"
+fi
+
 # =============================================================================
 # Domain Modeling Suggestion
 # =============================================================================
@@ -103,6 +130,15 @@ if [[ "$exit_code" == "0" ]] && echo "$output" | grep -qi "Domain Modeling"; the
     log_pass "FR 'crée une entité' detects domain modeling suggestion"
 else
     log_fail "FR 'crée une entité' should detect domain modeling" "exit=$exit_code"
+fi
+
+result=$(run_bias "crea una entidad Usuario")
+exit_code="${result%%|*}"
+output="${result#*|}"
+if [[ "$exit_code" == "0" ]] && echo "$output" | grep -qi "Domain Modeling"; then
+    log_pass "ES 'crea una entidad' detects domain modeling suggestion"
+else
+    log_fail "ES 'crea una entidad' should detect domain modeling" "exit=$exit_code"
 fi
 
 # =============================================================================
@@ -145,6 +181,42 @@ if [[ "$exit_code" == "0" ]] && [[ -z "$output" || ! "$output" =~ "BIAS DETECTED
     log_pass "'summarize the changes' no false positive"
 else
     log_fail "'summarize the changes' should not detect bias" "got output: $output"
+fi
+
+result=$(run_bias "el arreglo rápido pasó todas las pruebas")
+exit_code="${result%%|*}"
+output="${result#*|}"
+if [[ "$exit_code" == "0" ]] && [[ -z "$output" ]]; then
+    log_pass "ES descriptive use of 'rápido' has no false positive"
+else
+    log_fail "ES descriptive 'rápido' should not detect bias" "got output: $output"
+fi
+
+result=$(run_bias "además, el registro muestra el error")
+exit_code="${result%%|*}"
+output="${result#*|}"
+if [[ "$exit_code" == "0" ]] && [[ -z "$output" ]]; then
+    log_pass "ES non-imperative 'además' has no false positive"
+else
+    log_fail "ES non-imperative 'además' should not detect bias" "got output: $output"
+fi
+
+result=$(run_bias "documenta la configuración para el futuro")
+exit_code="${result%%|*}"
+output="${result#*|}"
+if [[ "$exit_code" == "0" ]] && [[ -z "$output" ]]; then
+    log_pass "ES descriptive future use has no false positive"
+else
+    log_fail "ES descriptive future use should not detect bias" "got output: $output"
+fi
+
+result=$(run_bias "explica qué es una entidad")
+exit_code="${result%%|*}"
+output="${result#*|}"
+if [[ "$exit_code" == "0" ]] && [[ -z "$output" ]]; then
+    log_pass "ES explanatory 'entidad' has no false positive"
+else
+    log_fail "ES explanatory 'entidad' should not detect bias" "got output: $output"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- add Spanish patterns for acceleration, scope creep, over-optimization, and domain-modeling prompts
- keep the new matches context-aware by requiring an explicit action or intent instead of matching isolated Spanish keywords
- add positive and near-miss coverage and update the language support documentation

The hook remains warning-only and continues to use the existing FR/EN pattern structure.

## Verification

- `./tests/core/test-bias-detector.sh` — 23 passed, 0 failed
- `./tests/run-tests.sh` — 229 passed, 0 failed, 0 skipped
- `bash -n hooks/bias-detector.sh tests/core/test-bias-detector.sh`
- ShellCheck on the modified hook and test file
- uppercase Spanish prompt smoke and `git diff --check`

Closes #10
