### PR TITLE
feat(adapters): host adapter contract (ADR-0029) with Hermes gate self-protection and parity suite

### DIFF
--- a/.craftsman-baseline.json
+++ b/.craftsman-baseline.json
@@ -105,6 +105,7 @@
 {"complexity":5,"fan_out":0,"file_lines":198,"ignores":0,"max_fn_lines":22,"path":"scripts/consolidate-metrics.sh"},
 {"complexity":5,"fan_out":0,"file_lines":214,"ignores":0,"max_fn_lines":19,"path":"scripts/validate-pack.sh"},
 {"complexity":0,"fan_out":2,"file_lines":235,"ignores":0,"max_fn_lines":10,"path":"tests/adapters/test-hermes-pre-verify.sh"},
+{"complexity":1,"fan_out":5,"file_lines":152,"ignores":0,"max_fn_lines":8,"path":"tests/adapters/test-parity.sh"},
 {"complexity":0,"fan_out":0,"file_lines":6,"ignores":0,"max_fn_lines":6,"path":"tests/ci/fixtures/invalid-any.ts"},
 {"complexity":0,"fan_out":1,"file_lines":21,"ignores":0,"max_fn_lines":6,"path":"tests/ci/fixtures/invalid-layer-violation.php"},
 {"complexity":0,"fan_out":0,"file_lines":11,"ignores":0,"max_fn_lines":5,"path":"tests/ci/fixtures/invalid-no-strict.php"},

--- a/.craftsman-baseline.json
+++ b/.craftsman-baseline.json
@@ -1,7 +1,7 @@
 [
 {"complexity":6,"fan_out":0,"file_lines":260,"ignores":0,"max_fn_lines":28,"path":".github/scripts/secrets-scan.sh"},
 {"complexity":16,"fan_out":0,"file_lines":67,"ignores":0,"max_fn_lines":67,"path":"adapters/hermes/claude-craftsman.sh"},
-{"complexity":3,"fan_out":6,"file_lines":188,"ignores":0,"max_fn_lines":16,"path":"adapters/hermes/pre-verify.sh"},
+{"complexity":3,"fan_out":7,"file_lines":227,"ignores":0,"max_fn_lines":16,"path":"adapters/hermes/pre-verify.sh","reason":"ADR-0029: gate self-protection guard and advisory channel (CR-45, CR-46)"},
 {"complexity":4,"fan_out":5,"file_lines":195,"ignores":0,"max_fn_lines":22,"path":"ci/adapters/adapter.sh","reason":"CI annotation delivery: adapter_compute_exit now reads files_scanned, so a run that opened no file fails closed in ci mode as it already did in direct mode, and auto-detection routes through each provider's adapter_detect instead of reimplementing the env-var chain. adapter_format_comment was decomposed into read, header and issue table, so complexity fell 13 to 4 and max_fn_lines 66 to 22; file_lines and fan_out rise for that decomposition and for the recorded ground truth."},
 {"complexity":8,"fan_out":2,"file_lines":229,"ignores":0,"max_fn_lines":52,"path":"ci/adapters/bitbucket.sh","reason":"CI annotation delivery: the report and annotation PUTs no longer discard their status, so an undelivered verdict is visible, and Pipelines uses the documented credential-free proxy on localhost:29418 instead of requiring a Bearer token the template described as an app password. complexity fell 14 to 8; file_lines rises for the transport helper and the recorded ground truth."},
 {"complexity":2,"fan_out":1,"file_lines":60,"ignores":0,"max_fn_lines":17,"path":"ci/adapters/generic.sh"},
@@ -104,7 +104,7 @@
 {"complexity":4,"fan_out":0,"file_lines":131,"ignores":0,"max_fn_lines":24,"path":"scripts/bump-version.sh"},
 {"complexity":5,"fan_out":0,"file_lines":198,"ignores":0,"max_fn_lines":22,"path":"scripts/consolidate-metrics.sh"},
 {"complexity":5,"fan_out":0,"file_lines":214,"ignores":0,"max_fn_lines":19,"path":"scripts/validate-pack.sh"},
-{"complexity":0,"fan_out":2,"file_lines":235,"ignores":0,"max_fn_lines":10,"path":"tests/adapters/test-hermes-pre-verify.sh"},
+{"complexity":0,"fan_out":2,"file_lines":272,"ignores":0,"max_fn_lines":11,"path":"tests/adapters/test-hermes-pre-verify.sh","reason":"ADR-0029: red-first assertions for gate self-edit and advisory findings"},
 {"complexity":1,"fan_out":5,"file_lines":152,"ignores":0,"max_fn_lines":8,"path":"tests/adapters/test-parity.sh"},
 {"complexity":0,"fan_out":0,"file_lines":6,"ignores":0,"max_fn_lines":6,"path":"tests/ci/fixtures/invalid-any.ts"},
 {"complexity":0,"fan_out":1,"file_lines":21,"ignores":0,"max_fn_lines":6,"path":"tests/ci/fixtures/invalid-layer-violation.php"},
@@ -181,6 +181,6 @@
 {"complexity":0,"fan_out":3,"file_lines":289,"ignores":3,"max_fn_lines":7,"path":"tests/packs/test-security.sh"},
 {"complexity":0,"fan_out":5,"file_lines":139,"ignores":0,"max_fn_lines":1,"path":"tests/packs/test-structural.sh"},
 {"complexity":0,"fan_out":5,"file_lines":118,"ignores":0,"max_fn_lines":1,"path":"tests/packs/test-symfony.sh"},
-{"complexity":24,"fan_out":1,"file_lines":820,"ignores":1,"max_fn_lines":125,"path":"tests/run-tests.sh","reason":"register tests/core/test-gate-independence.sh"},
+{"complexity":25,"fan_out":1,"file_lines":821,"ignores":1,"max_fn_lines":125,"path":"tests/run-tests.sh","reason":"ADR-0029: wire the host adapter parity suite (one run_subtest line)"},
 {"complexity":0,"fan_out":0,"file_lines":344,"ignores":0,"max_fn_lines":5,"path":"tests/templates/test-templates.sh"}
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,10 +708,56 @@ jobs:
 
           echo "SUCCESS: no structural regression on changed files."
 
+  hermes-adapter-image:
+    name: Hermes Adapter Image
+    runs-on: ubuntu-latest
+    needs: [secrets-scan]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      # The image is multi-gigabyte and the adapter changes rarely: build only
+      # when the adapter, the gate it wraps, or this workflow changed.
+      - name: Detect adapter changes
+        id: adapter
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE"...HEAD | grep -qE '^(adapters/hermes/|ci/craftsman-ci\.sh|\.github/workflows/ci\.yml)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Adapter untouched, skipping the image build."
+          fi
+
+      # Pinned by digest: the Dockerfile's own argument for baking the plugin
+      # into the image is "no change with no diff, no review and no history",
+      # and :latest is exactly that.
+      - name: Build craftsman layer on the pinned Hermes image
+        if: steps.adapter.outputs.changed == 'true'
+        run: |
+          docker build -f adapters/hermes/Dockerfile.craftsman             --build-arg HERMES_IMAGE=nousresearch/hermes-agent@sha256:aa7d34353e0bafbad0ce76a6ea1dffd165acb10dc521c81b1315610d5d025a09             -t hermes-craftsman .
+
+      - name: Smoke the pre_verify gate inside the image
+        if: steps.adapter.outputs.changed == 'true'
+        run: |
+          docker run --rm hermes-craftsman bash -c '
+            set -e
+            command -v jq sqlite3 claude >/dev/null
+            mkdir -p /tmp/w && cd /tmp/w && git init -q .
+            printf "const bad: any = 1;\n" > bad.ts
+            printf "%s" "{\"hook_event_name\":\"pre_verify\",\"cwd\":\"/tmp/w\",\"extra\":{\"coding\":true,\"changed_paths\":[\"bad.ts\"],\"attempt\":0}}"               | /opt/craftsman/adapters/hermes/pre-verify.sh | grep -q "\"decision\": \"block\""
+            echo "gate blocks inside the container"
+          '
+
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [secrets-scan, validate-json, validate-hooks-schema, validate-plugin-manifest, validate-shell-scripts, validate-skills, validate-knowledge-base, lint-python, run-tests, check-agents, structural-ratchet]
+    needs: [secrets-scan, validate-json, validate-hooks-schema, validate-plugin-manifest, validate-shell-scripts, validate-skills, validate-knowledge-base, lint-python, run-tests, check-agents, structural-ratchet, hermes-adapter-image]
     if: always()
     steps:
       - name: Check all jobs status
@@ -734,6 +780,7 @@ jobs:
           echo "  - Test suite: ${{ needs.run-tests.result }}"
           echo "  - Agent definitions: ${{ needs.check-agents.result }}"
           echo "  - Structural ratchet: ${{ needs.structural-ratchet.result }}"
+          echo "  - Hermes adapter image: ${{ needs.hermes-adapter-image.result }}"
           echo ""
 
           # Fail if any job failed
@@ -747,7 +794,8 @@ jobs:
              [[ "${{ needs.lint-python.result }}" == "failure" ]] || \
              [[ "${{ needs.run-tests.result }}" == "failure" ]] || \
              [[ "${{ needs.check-agents.result }}" == "failure" ]] || \
-             [[ "${{ needs.structural-ratchet.result }}" == "failure" ]]; then
+             [[ "${{ needs.structural-ratchet.result }}" == "failure" ]] || \
+             [[ "${{ needs.hermes-adapter-image.result }}" == "failure" ]]; then
             echo "FAILED: One or more validation jobs failed"
             exit 1
           fi

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -44,6 +44,23 @@ scope from `git diff` plus untracked files and treats the payload as a hint.
 
 A dirty worktree is therefore unverified work, and all of it is scanned.
 
+### One verdict, two channels
+
+Critical violations block the conclusion, and carry the advisory findings
+along so they are read in the same turn. A turn with only advisory findings
+gets them once, as a `continue` directive on the first attempt, and silence on
+every later one: repeated, advice would burn `agent.max_verify_nudges`;
+dropped, it would break verdict parity with the hook and CI front-ends
+(ADR-0029, `tests/adapters/test-parity.sh`).
+
+### The gate refuses its own reconfiguration
+
+A turn whose diff touches `.craft-rules.yml`, `.craft-config.yml`,
+`adapters/hermes/` or `ci/craftsman-ci.sh` is blocked outright, whatever else
+it contains. Hermes consent survives script edits (the allowlist keys on the
+command string, not a hash), so this is the one containment measure that
+lives in this repository rather than in infrastructure.
+
 ## Path 2: Claude Code inside the container
 
 Hermes ships `skills/autonomous-ai-agents/claude-code/SKILL.md`, which tells
@@ -86,10 +103,13 @@ image; only session state belongs on the volume.
 
 Stated plainly, because a control that does not control is worse than none.
 
-**The gated party configures the gate.** A `.craft-rules.yml` next to a
-violating file switches its rule to `ignore` and the gate goes silent.
-`trust_project_tools` in `~/.claude/.craft-config.yml` turns a config toggle
-into execution of a cloned repository's own binaries. Both reproduced.
+**The gated party configures the gate, and the refusal above only covers the
+turn.** A `.craft-rules.yml` that was already in the repository when it was
+cloned, or one edited outside a gated turn, still switches its rule to
+`ignore` with no refusal. `trust_project_tools` in `~/.claude/.craft-config.yml`
+turns a config toggle into execution of a cloned repository's own binaries.
+Both reproduced before the in-turn guard existed, and both remain live outside
+it.
 
 The stock image runs as uid 0, so file permissions contain nobody. Containment
 needs one of:

--- a/adapters/hermes/pre-verify.sh
+++ b/adapters/hermes/pre-verify.sh
@@ -94,6 +94,8 @@ elif value is not None:
 HINTED_PATHS=$(_field changed_paths)
 CODING=$(_field coding)
 CWD=$(_field cwd)
+ATTEMPT=$(_field attempt)
+[[ "$ATTEMPT" =~ ^[0-9]+$ ]] || ATTEMPT=0
 
 # Scope like a pre_tool_call hook scopes on tool_name: a non-coding session has
 # nothing for this gate to say.
@@ -147,10 +149,22 @@ target = os.path.realpath(os.path.join(root, sys.argv[2]))
 inside = target == root or target.startswith(root + os.sep)
 print(os.path.relpath(target, root) if inside else "")
 ' "$CWD" "$path" 2>/dev/null)
-    [[ -n "$resolved" && -f "$resolved" ]] || continue
+    [[ -n "$resolved" ]] || continue
+    # The gated party configures the gate: a turn that edits the rule files
+    # could switch its own violations to `ignore` before this scan reads them,
+    # and Hermes consent survives script edits (the allowlist keys on the
+    # command string, not a hash). Deletions count, so this runs before the
+    # existence filter.
+    case "$resolved" in
+        .craft-rules.yml|.craft-config.yml|*/.craft-rules.yml|*/.craft-config.yml|adapters/hermes/*|ci/craftsman-ci.sh)
+            GATE_TOUCHED="$resolved" ;;
+    esac
+    [[ -f "$resolved" ]] || continue
     case " ${SCAN_PATHS[*]:-} " in *" $resolved "*) continue ;; esac
     SCAN_PATHS+=("$resolved")
 done <<< "$(printf '%s\n%s\n' "$(_git_scope)" "$HINTED_PATHS")"
+
+[[ -n "${GATE_TOUCHED:-}" ]] && _verdict "This turn edits the craftsman gate's own configuration (${GATE_TOUCHED}). The gated party does not reconfigure the gate: revert that file and change the rules through a reviewed commit instead."
 
 [[ ${#SCAN_PATHS[@]} -gt 0 ]] || exit 0
 
@@ -162,26 +176,51 @@ REPORT=$(portable_timeout "${CRAFTSMAN_GATE_SECONDS:-45}" \
 [[ "$GATE_STATUS" -eq 124 ]] && _bail "gate exceeded ${CRAFTSMAN_GATE_SECONDS:-45}s on ${#SCAN_PATHS[@]} file(s), verdict unknown"
 [[ -n "$REPORT" ]] || _bail "gate produced no report (exit ${GATE_STATUS}), verdict unknown"
 
+# One verdict, two channels. Criticals block, and carry the advisory findings
+# along so they are read in the same turn. Advisory-only surfaces once, as a
+# continue directive on the first attempt: repeated on every nudge it would
+# burn agent.max_verify_nudges on advice, dropped it would break verdict
+# parity with the hook and CI front-ends.
 SUMMARY=$(printf '%s' "$REPORT" | python3 -c '
 import json, sys
 try:
     report = json.load(sys.stdin)
 except (ValueError, TypeError):
     sys.exit(0)
+def line(v):
+    return "{}:{} {} - {}".format(v.get("file", "?"), v.get("line", 0), v.get("rule", "?"), v.get("message", ""))
 violations = report.get("violations") or []
 blocking = [v for v in violations if v.get("severity") == "critical"]
-if not blocking:
-    sys.exit(0)
-lines = [
-    "{}:{} {} - {}".format(v.get("file", "?"), v.get("line", 0), v.get("rule", "?"), v.get("message", ""))
-    for v in blocking[:10]
-]
-more = len(blocking) - len(lines)
-if more > 0:
-    lines.append("and {} more".format(more))
-print("The craftsman gate rejects this change, so it is not finished:\n" + "\n".join(lines)
-      + "\nFix these and say what you ran to prove it.")
-' 2>/dev/null)
+advisory = [v for v in violations if v.get("severity") != "critical"]
+attempt = int(sys.argv[1])
+if blocking:
+    lines = [line(v) for v in blocking[:10]]
+    more = len(blocking) - len(lines)
+    if more > 0:
+        lines.append("and {} more".format(more))
+    if advisory:
+        lines.append("Also worth fixing, non-blocking:")
+        lines.extend(line(v) for v in advisory[:3])
+    print("BLOCK")
+    print("The craftsman gate rejects this change, so it is not finished:\n" + "\n".join(lines)
+          + "\nFix these and say what you ran to prove it.")
+elif advisory and attempt == 0:
+    lines = [line(v) for v in advisory[:5]]
+    more = len(advisory) - len(lines)
+    if more > 0:
+        lines.append("and {} more".format(more))
+    print("NUDGE")
+    print("Non-blocking craftsman findings, consider them before concluding:\n" + "\n".join(lines))
+' "$ATTEMPT" 2>/dev/null)
 
-[[ -n "$SUMMARY" ]] && _verdict "$SUMMARY"
+[[ -n "$SUMMARY" ]] || exit 0
+MODE="${SUMMARY%%$'\n'*}"
+MESSAGE="${SUMMARY#*$'\n'}"
+[[ "$MODE" == "BLOCK" ]] && _verdict "$MESSAGE"
+if [[ "$MODE" == "NUDGE" ]]; then
+    python3 -c '
+import json, sys
+print(json.dumps({"action": "continue", "message": sys.argv[1]}, ensure_ascii=False))
+' "$MESSAGE"
+fi
 exit 0

--- a/docs/adr/0029-host-adapter-contract.md
+++ b/docs/adr/0029-host-adapter-contract.md
@@ -1,0 +1,95 @@
+# ADR-0029: Host Adapter Contract
+
+## Status
+
+Accepted.
+
+## Date
+
+2026-08-26
+
+## Context
+
+The plugin has three front-ends over one core: `hooks/` for Claude Code,
+`ci/craftsman-ci.sh` for pipelines, and `adapters/hermes/` for Nous Research's
+Hermes runtime. CLAUDE.md already states the rule ("a fourth front-end is an
+adapter, never a fork") and `tests/ci/test-craftsman-ci.sh` holds hooks and CI
+to the same severity resolution. Nothing held the Hermes adapter to anything.
+
+Three gaps followed, all found in review:
+
+1. The Hermes adapter dropped every non-critical violation
+   (`pre-verify.sh` filtered `severity == "critical"` and discarded the rest),
+   so the "one engine, one verdict" claim was false on that host.
+2. The gate did not protect its own configuration. A turn that wrote
+   `.craft-rules.yml` next to a violating file switched the rule to `ignore`
+   before the scan read it, and Hermes consent survives script edits (the
+   allowlist keys on the command string, not a hash). The Dockerfile documented
+   this refusal as the one containment measure living in this repository; it
+   was not implemented.
+3. No test compared the three front-ends on the same fixtures, so a fourth
+   adapter could drift on day one without any suite noticing.
+
+The multi-host precedent worth contrasting is ECC, which supports many hosts by
+copying agents, rules and hooks into per-host directories and warns its own
+users about the duplication. The premise here is the opposite: one engine,
+adapters at the edge, parity enforced by tests.
+
+An adversarial design panel reviewed the first draft of this contract. It cut
+a `verify` verb (operational health belongs to each host's own doctor command),
+cut a speculative event catalogue (the `violations`, `corrections` and
+`instincts` tables are the model), and forced two clarifications recorded
+below: a gate returns exactly `pass` or `block`, and the instinct projection is
+a projection, never a second system of record.
+
+## Decision
+
+Every host adapter implements three verbs against the shared core:
+
+| Verb | Responsibility |
+|------|----------------|
+| `gate` | Run the rules engine on the turn's scope and return exactly `pass` or `block`. A gate that cannot run returns `block` with the reason: no verdict is not a clean verdict. A turn whose scope touches the gate's own configuration (`.craft-rules.yml`, `.craft-config.yml`, the adapter's own files, `ci/craftsman-ci.sh`) is blocked, not flagged. Non-critical findings are surfaced with the verdict, never dropped: they ride along with a block, and on a host where advice costs a turn they surface once, on the first attempt. |
+| `inject` | Put correction trends and approved instincts into the agent's context at session start. CI has no agent to inform and does not implement it. |
+| `record` | Write violations and corrections into `metrics.db` with `source=<host>` and enough threading (session id, attempt) to tie a correction to the violation it fixed. |
+
+Enforcement is `tests/adapters/test-parity.sh`: the same fixtures (a LAYER001
+domain import, a TS001 `any`, an advisory TS002, a directory-level
+`.craft-rules.yml` relaxation) run through every front-end, and the suite fails
+when two front-ends disagree on a rule's blocking decision, and when a
+directory under `adapters/` has no parity coverage at all.
+
+`metrics.db` is the single system of record for violations, corrections and
+instincts. On a host with no human at the keyboard, instinct candidates may be
+exported as files in the repository so that a reviewed merge becomes the
+approval gesture, but such an export is a projection: regenerated from the
+database, never merged back by hand, and the merge lands in the database
+through `instincts.py approve`. Codification stays human-gated on every host.
+
+## Alternatives rejected
+
+- **Per-host copies of rules and workflows (ECC's model).** Ships fast,
+  drifts guaranteed, and contradicts the adapter rule this repository already
+  enforces between hooks and CI.
+- **A `verify` verb in the contract.** Adapter health is deployment, not
+  architecture: `hermes hooks doctor` and `/craftsman:healthcheck` already own
+  it per host.
+- **A domain event catalogue.** Seven event types were drafted; two tables were
+  in use. The tables are the contract.
+
+## Consequences
+
+- The Hermes adapter now blocks a turn that edits the gate's configuration and
+  surfaces advisory findings once per turn cycle instead of dropping them.
+  `tests/adapters/test-hermes-pre-verify.sh` covers both, red-first.
+- A future host (a native Hermes Python plugin, Cursor, Codex) starts from this
+  contract and from a parity entry, or the suite refuses it.
+- The parity suite runs the real front-end entry points, not the engine
+  directly, so an adapter that swallows the engine's verdict fails even when
+  the engine was right.
+
+## Re-evaluate if
+
+- A host appears whose only integration surface cannot block anything, making
+  `gate` unimplementable as specified.
+- Instinct approval needs to synchronise across machines, which would reopen
+  the projection-versus-record question that the panel closed here.

--- a/tests/adapters/test-hermes-pre-verify.sh
+++ b/tests/adapters/test-hermes-pre-verify.sh
@@ -38,8 +38,9 @@ print(json.dumps({
     "hook_event_name": "pre_verify", "tool_name": None, "tool_input": None,
     "session_id": "s1", "cwd": sys.argv[1],
     "extra": {"changed_paths": sys.argv[2].split(","), "coding": sys.argv[3] == "1",
-              "attempt": 0, "final_response": "done", "model": "m", "platform": "cli"},
-}))' "$WORK" "$1" "$2"
+              "attempt": int(sys.argv[4]), "final_response": "done", "model": "m",
+              "platform": "cli"},
+}))' "$WORK" "$1" "$2" "${3:-0}"
 }
 
 OUT=$(_payload "src/Bad.ts" 1 | bash "$HOOK" 2>/dev/null)
@@ -104,6 +105,42 @@ if [[ -z "$OUT" ]]; then
 else
     log_fail "spurious verdict" "$OUT"
 fi
+
+# The gated party configures the gate: a turn that edits .craft-rules.yml or
+# .craft-config.yml could switch its own violations to `ignore` before the scan
+# reads them, and consent in Hermes survives script edits (the allowlist keys
+# on the command string, not a hash). Such a turn is refused outright.
+printf 'TS001: ignore\n' > .craft-rules.yml
+OUT=$(_payload "" 1 | bash "$HOOK" 2>/dev/null)
+if printf '%s' "$OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get("decision")=="block" else 1)' 2>/dev/null; then
+    log_pass "a turn that edits the gate's own configuration is refused"
+else
+    log_fail "gate self-edit accepted" "expected a block, got: ${OUT:-<empty>}"
+fi
+if printf '%s' "$OUT" | grep -q "craft-rules"; then
+    log_pass "the refusal names the gate file the turn touched"
+else
+    log_fail "unnamed gate file" "$OUT"
+fi
+rm -f .craft-rules.yml
+
+# Non-critical findings surface once, on the first attempt, and never block: a
+# warning repeated on every nudge would burn max_verify_nudges on advice, and a
+# warning dropped entirely would break verdict parity with the other front-ends.
+printf 'export default function f() { return 1 }\n' > src/Warn.ts
+OUT=$(_payload "src/Warn.ts" 1 0 | bash "$HOOK" 2>/dev/null)
+if [[ -n "$OUT" ]] && ! printf '%s' "$OUT" | grep -q '"decision"' && printf '%s' "$OUT" | grep -q "TS002"; then
+    log_pass "advisory findings are surfaced without a block directive"
+else
+    log_fail "warnings dropped or blocking" "attempt 0 on a warn-only turn gave: ${OUT:-<empty>}"
+fi
+OUT=$(_payload "src/Warn.ts" 1 1 | bash "$HOOK" 2>/dev/null)
+if [[ -z "$OUT" ]]; then
+    log_pass "advisory findings stay silent after the first attempt"
+else
+    log_fail "warning loop" "attempt 1 still nudges: $OUT"
+fi
+rm -f src/Warn.ts
 
 # An autonomous agent commits. Scope taken from the worktree alone left a
 # committed violation invisible: clean worktree, silent gate, everything the

--- a/tests/adapters/test-parity.sh
+++ b/tests/adapters/test-parity.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Host adapter parity (ADR-0029).
+#
+# One rules engine, one verdict: for the same file under the same rule set,
+# every front-end resolves the same rule ids to the same blocking decision.
+# The fixtures run through the three front-ends that exist today: the Claude
+# Code hooks, ci/craftsman-ci.sh, and the Hermes pre_verify adapter. A new
+# directory under adapters/ that this suite does not cover fails the last
+# assertion: an adapter without parity coverage is a fork, not an adapter.
+# =============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../lib/test-helpers.sh"
+
+export CLAUDE_PLUGIN_ROOT="$ROOT_DIR"
+export CLAUDE_PLUGIN_DATA="${TMPDIR:-/tmp}/craftsman-parity-$$"
+export CLAUDE_PLUGIN_OPTION_stack="fullstack"
+export CLAUDE_PLUGIN_OPTION_strictness="strict"
+mkdir -p "$CLAUDE_PLUGIN_DATA"
+
+HERMES_HOOK="$ROOT_DIR/adapters/hermes/pre-verify.sh"
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/craftsman-parity.XXXXXX")
+PREV_PWD="$PWD"
+
+echo ""
+echo "=== host adapter parity (ADR-0029) ==="
+
+mkdir -p "$WORK/src/Domain/User" "$WORK/relaxed"
+cd "$WORK" && git init -q . 2>/dev/null
+printf 'rules:\n  TS001: ignore\n' > relaxed/.craft-rules.yml
+git add -A >/dev/null 2>&1
+git -c user.email=t@t -c user.name=t commit -qm base >/dev/null 2>&1
+
+_hermes() {
+    python3 -c '
+import json, sys
+print(json.dumps({"hook_event_name": "pre_verify", "session_id": "s1",
+                  "cwd": sys.argv[1],
+                  "extra": {"changed_paths": [], "coding": True, "attempt": 0}}))' "$WORK" \
+        | bash "$HERMES_HOOK" 2>/dev/null
+}
+
+_ci_rules_for() {
+    bash "$ROOT_DIR/ci/craftsman-ci.sh" --format json "$1" 2>/dev/null | python3 -c '
+import json, sys
+report = json.load(sys.stdin)
+for v in report.get("violations") or []:
+    print(v.get("rule"), v.get("severity"))'
+}
+
+_clean() { git checkout -q -- . 2>/dev/null; git clean -qfd 2>/dev/null; mkdir -p src relaxed; }
+
+# --- LAYER001, critical, enforced pre-write -------------------------------
+PHP_FILE="$WORK/src/Domain/User/User.php"
+PHP_CONTENT='<?php
+declare(strict_types=1);
+namespace App\Domain\User;
+use App\Infrastructure\Persistence\DoctrineUserRepository;
+final class User {}'
+
+RC=0
+HOOK_OUT=$(python3 -c '
+import json, sys
+print(json.dumps({"tool_input": {"file_path": sys.argv[1], "content": sys.argv[2]}}))' \
+    "$PHP_FILE" "$PHP_CONTENT" | bash "$ROOT_DIR/hooks/pre-write-check.sh" 2>&1) || RC=$?
+printf '%s' "$PHP_CONTENT" > "$PHP_FILE"
+CI_OUT=$(_ci_rules_for "src/Domain/User/User.php")
+HERMES_OUT=$(_hermes)
+if [[ "$RC" -eq 2 ]] && printf '%s' "$HOOK_OUT" | grep -q "LAYER001" \
+    && printf '%s' "$CI_OUT" | grep -q "^LAYER001 critical" \
+    && printf '%s' "$HERMES_OUT" | grep -q '"decision"' \
+    && printf '%s' "$HERMES_OUT" | grep -q "LAYER001"; then
+    log_pass "LAYER001 blocks identically in hooks, CI and Hermes"
+else
+    log_fail "LAYER001 parity" "hook rc=$RC ci=[$CI_OUT] hermes=[$HERMES_OUT]"
+fi
+_clean
+
+# --- TS001, critical, enforced post-write ---------------------------------
+printf 'const bad: any = 1;\n' > "$WORK/src/Bad.ts"
+RC=0
+HOOK_OUT=$(printf '{"tool_input":{"file_path":"%s"}}' "$WORK/src/Bad.ts" \
+    | bash "$ROOT_DIR/hooks/post-write-check.sh" 2>&1) || RC=$?
+CI_OUT=$(_ci_rules_for "src/Bad.ts")
+HERMES_OUT=$(_hermes)
+if [[ "$RC" -eq 2 ]] && printf '%s' "$HOOK_OUT" | grep -q "TS001" \
+    && printf '%s' "$CI_OUT" | grep -q "^TS001 critical" \
+    && printf '%s' "$HERMES_OUT" | grep -q '"decision"' \
+    && printf '%s' "$HERMES_OUT" | grep -q "TS001"; then
+    log_pass "TS001 blocks identically in hooks, CI and Hermes"
+else
+    log_fail "TS001 parity" "hook rc=$RC ci=[$CI_OUT] hermes=[$HERMES_OUT]"
+fi
+_clean
+
+# --- TS002, advisory: reported everywhere, blocks nowhere -----------------
+printf 'export default function f() { return 1 }\n' > "$WORK/src/Warn.ts"
+RC=0
+HOOK_OUT=$(printf '{"tool_input":{"file_path":"%s"}}' "$WORK/src/Warn.ts" \
+    | bash "$ROOT_DIR/hooks/post-write-check.sh" 2>&1) || RC=$?
+CI_OUT=$(_ci_rules_for "src/Warn.ts")
+HERMES_OUT=$(_hermes)
+if [[ "$RC" -eq 0 ]] \
+    && printf '%s' "$CI_OUT" | grep -q "^TS002" \
+    && ! printf '%s' "$CI_OUT" | grep -q "^TS002 critical" \
+    && [[ -n "$HERMES_OUT" ]] \
+    && ! printf '%s' "$HERMES_OUT" | grep -q '"decision"' \
+    && printf '%s' "$HERMES_OUT" | grep -q "TS002"; then
+    log_pass "TS002 stays advisory in hooks, CI and Hermes"
+else
+    log_fail "TS002 parity" "hook rc=$RC ci=[$CI_OUT] hermes=[$HERMES_OUT]"
+fi
+_clean
+
+# --- directory relaxation applies in every front-end ----------------------
+printf 'const relaxed: any = 1;\n' > "$WORK/relaxed/Bad.ts"
+RC=0
+HOOK_OUT=$(printf '{"tool_input":{"file_path":"%s"}}' "$WORK/relaxed/Bad.ts" \
+    | bash "$ROOT_DIR/hooks/post-write-check.sh" 2>&1) || RC=$?
+CI_OUT=$(_ci_rules_for "relaxed/Bad.ts")
+HERMES_OUT=$(_hermes)
+if [[ "$RC" -eq 0 ]] \
+    && ! printf '%s' "$CI_OUT" | grep -q "^TS001" \
+    && [[ -z "$HERMES_OUT" ]]; then
+    log_pass "a directory .craft-rules.yml relaxation holds in hooks, CI and Hermes"
+else
+    log_fail "relaxation parity" "hook rc=$RC ci=[$CI_OUT] hermes=[$HERMES_OUT]"
+fi
+_clean
+
+# --- every adapter directory is covered here ------------------------------
+UNCOVERED=""
+for dir in "$ROOT_DIR"/adapters/*/; do
+    case "$(basename "$dir")" in
+        hermes) ;;
+        *) UNCOVERED="${UNCOVERED}$(basename "$dir") " ;;
+    esac
+done
+if [[ -z "$UNCOVERED" ]]; then
+    log_pass "every adapters/ directory has parity coverage in this suite"
+else
+    log_fail "uncovered adapter" "add parity cases for: $UNCOVERED"
+fi
+
+cd "$PREV_PWD"
+rm -rf "$WORK" "$CLAUDE_PLUGIN_DATA"
+
+test_summary

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -612,6 +612,7 @@ test_session_metrics() {
     run_subtest "CI adapter tests pass" "$SCRIPT_DIR/ci/test-adapters.sh" || true
     run_subtest "CI adapter delivery tests pass" "$SCRIPT_DIR/ci/test-adapter-delivery.sh" || true
     run_subtest "Hermes pre_verify adapter tests pass" "$SCRIPT_DIR/adapters/test-hermes-pre-verify.sh" || true
+    run_subtest "Host adapter parity tests pass" "$SCRIPT_DIR/adapters/test-parity.sh" || true
     run_subtest "Doctrine export tests pass" "$SCRIPT_DIR/ci/test-doctrine-export.sh" || true
     run_subtest "Rule registry tests pass" "$SCRIPT_DIR/ci/test-rule-registry.sh" || true
     run_subtest "Ratchet CI parity tests pass" "$SCRIPT_DIR/ci/test-ratchet-ci.sh" || true


### PR DESCRIPTION
## What

- **ADR-0029**: every host front-end implements three verbs (`gate`, `inject`, `record`) against the shared core. A gate returns exactly pass or block; no verdict is a block; the gated party never reconfigures the gate mid-turn; metrics.db stays the single system of record for the learning loop.
- **Hermes gate self-protection** (closes #13): a turn whose diff touches `.craft-rules.yml`, `.craft-config.yml`, `adapters/hermes/` or `ci/craftsman-ci.sh` is refused outright. The Dockerfile documented this refusal as the one containment measure living in this repository; it was not implemented.
- **Advisory findings no longer dropped on Hermes** (closes #14): they ride along with a block, and a warn-only turn surfaces them once, on the first attempt, as a continue directive. Silence afterwards, so advice never burns `agent.max_verify_nudges`.
- **Parity suite** (closes #16): `tests/adapters/test-parity.sh` runs the same fixtures (LAYER001, TS001, advisory TS002, a directory `.craft-rules.yml` relaxation) through the Claude Code hooks, `ci/craftsman-ci.sh` and the Hermes adapter, asserts identical blocking decisions, and fails for any `adapters/` directory without coverage.
- **CI builds the adapter image** (closes #15): new `hermes-adapter-image` job, digest-pinned base, gate smoked inside the container, skipped when the adapter is untouched.

## Evidence

- Red first: the CR-45/CR-46 assertions failed before the implementation (3 failures observed), green after.
- `bash tests/run-tests.sh`: 251 passed, 0 failed, 0 skipped.
- `tests/adapters/test-hermes-pre-verify.sh`: 19 -> 22 assertions.
- `tests/adapters/test-parity.sh`: 5 assertions, including the uncovered-adapter guard.

## Follow-ups filed

#17 (native Hermes plugin), #18 (learning loop via `attempt`), #19 (agentskills.io export), #20 (trust signals), #21 (opt-in pre_tool_call), #22 (install.sh --target).