### PR TITLE
fix(challenge): review side effects by frequency, not only by content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/craftsman:challenge` now reviews side effects by their frequency, not only
+  their content.** A new Level 2 smell (unthrottled side effect) plus the three
+  questions that expose it: who calls this and at what rate, does it repeat
+  identically, can an unauthenticated caller trigger it. Motivated by a real
+  miss: a fail-open warning was reviewed as correct while sitting on a
+  per-request path of a liveness endpoint, so one unreadable config would emit
+  one warning per probe and bury the line the operator needed.
+
 ## [4.9.0] - 2026-08-27
 
 ### Added

--- a/skills/challenge/SKILL.md
+++ b/skills/challenge/SKILL.md
@@ -72,6 +72,24 @@ Fix within the PR:
 | Feature envy | Method uses other object's data more |
 | Missing events | State changes without domain events |
 | Fat use case | UseCase doing >1 responsibility |
+| Unthrottled side effect | Log, metric, config read or lock on a per-call path, repeated identically |
+
+#### Side effects: judge the frequency, not only the content
+
+A side effect is correct or not **relative to how often it fires**. The same
+warning is right once at startup and a defect inside a request handler: an
+endpoint polled on a timer turns one broken config into a log flood that buries
+the line the operator needed. The content passes review; the defect ships.
+
+Ask it of every log line, metric, file read, lock or network call in the diff:
+
+- **Who calls this, at what rate?** A liveness probe, a poller and a retry loop
+  are all multipliers.
+- **Does it repeat identically?** Then it belongs behind a one-shot guard, a
+  cache or a dedup key. The codebase usually already has that pattern; reuse it
+  rather than inventing a second one.
+- **Can an unauthenticated caller trigger it?** I/O on a public path is a cost a
+  stranger controls.
 
 #### Level 3: Improvements (TECH DEBT)
 


### PR DESCRIPTION
## What

`/craftsman:challenge` judged what a side effect says and never how often it fires. This adds a Level 2 smell (**unthrottled side effect**) and the three questions that expose it.

## Why, from a real miss this week

While reviewing a hardening change on another project, the skill (and I) approved a fail-open warning as correct. It was correct: the message named the setting and the fallback. It was also sitting on a **per-request path of a liveness endpoint** that portals, uptime monitors and a desktop client poll on a timer, so a single unreadable config would have emitted one warning per probe and buried the line the operator needed.

An automated review on the upstream PR caught it precisely because it looked at the log's lifecycle rather than its wording. The content passed review; the defect shipped anyway. That is the gap this closes.

## Changes

- `skills/challenge/SKILL.md`: new row in the Level 2 table, plus a short subsection "Side effects: judge the frequency, not only the content" with the three checks:
  - who calls this and at what rate (probe, poller, retry loop are multipliers),
  - does it repeat identically (then a one-shot guard, cache or dedup key belongs there, and the codebase usually already has that pattern to reuse),
  - can an unauthenticated caller trigger it (I/O on a public path is a cost a stranger controls).
- `CHANGELOG.md`: entry under `[Unreleased]` recording the motivating miss, not just the feature.

## Verification

The change is instructional content for the review skill, so the check that matters is that the skill applies it. Exercised against the same diff that produced the miss: with the section in place, the frequency question surfaces the per-request warning and the finding lands as MUST FIX with the one-shot guard as the fix.

Local `tests/run-tests.sh`: **254 passed, 0 failed, 0 skipped** (the run finished after this PR was opened, hence the edit). Nothing in the diff touches hooks, rules or scripts, only skill prose and the changelog.
