### PR TITLE
docs(models): aliases do not follow model releases, and the guide said they did

### DIFF
--- a/.craftsman-baseline.json
+++ b/.craftsman-baseline.json
@@ -44,7 +44,7 @@
 {"complexity":6,"fan_out":7,"file_lines":154,"ignores":0,"max_fn_lines":22,"path":"hooks/lib/conventions.py"},
 {"complexity":4,"fan_out":8,"file_lines":277,"ignores":0,"max_fn_lines":20,"path":"hooks/lib/dashboard.py"},
 {"complexity":11,"fan_out":4,"file_lines":110,"ignores":0,"max_fn_lines":27,"path":"hooks/lib/dispatch-context.sh","reason":"extraction campaign: worst-span complexity 28 to 11, max_fn_lines 97 to 27; file_lines 97 to 110 is the function boilerplate paid for it"},
-{"complexity":5,"fan_out":0,"file_lines":58,"ignores":0,"max_fn_lines":15,"path":"hooks/lib/haiku-verify.sh","reason":"advisory effort gate: haiku_verify steps aside at CLAUDE_EFFORT=low, enforced by tests/core/test-gate-independence.sh"},
+{"complexity":5,"fan_out":0,"file_lines":68,"ignores":0,"max_fn_lines":15,"path":"hooks/lib/haiku-verify.sh","reason":"model tiering correction: the pin is documented, with its retirement date"},
 {"complexity":6,"fan_out":0,"file_lines":234,"ignores":0,"max_fn_lines":26,"path":"hooks/lib/healthcheck.sh","reason":"v4.4.0 language registry: hooks source config.sh and pack-loader.sh to read the registry, replacing ten duplicated case statements. fan_out rises because the dependency is now explicit; the coupling it measures went down."},
 {"complexity":3,"fan_out":0,"file_lines":74,"ignores":0,"max_fn_lines":17,"path":"hooks/lib/hook-events.sh"},
 {"complexity":6,"fan_out":1,"file_lines":72,"ignores":0,"max_fn_lines":22,"path":"hooks/lib/hook-profile.sh"},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`docs/guides/model-tiering-explained.md` claimed aliases follow model
+  releases.** They do not. The models overview states that every Claude model
+  ID is a pinned snapshot, including the dateless ones from the 4.6 generation
+  on, and that a dateless ID is its own snapshot rather than a pointer. So
+  `claude-opus-5` will not become the successor to Opus 5 on its own, and
+  moving a tier is an edit that belongs in a release. What an alias still buys,
+  remappability and per-provider resolution, is unchanged and now stated
+  without the false part. `hooks/lib/haiku-verify.sh` records why its pinned id
+  is pinned, and that it carries the nearest retirement date in the lineup.
+
 ### Added
 
 - **Go pack (`packs/go/`).** Seven owned rules plus NEST001, LOC001, PARAM001

--- a/docs/guides/model-tiering-explained.md
+++ b/docs/guides/model-tiering-explained.md
@@ -297,13 +297,23 @@ statement rather than a change. `xhigh` is genuinely above the default;
 ### Why aliases and not model ids
 
 Every tier is an alias (`haiku`, `sonnet`, `opus`), never a pinned id like
-`claude-opus-5`. Aliases resolve to the newest model in their family, so the
-plugin follows model releases without a version bump. It also makes the tiering
-remappable - see Overriding below.
+`claude-haiku-4-5-20251001`. What that buys is remappability, not automatic
+upgrades: a project overrides a tier in one place, see Overriding below.
 
-Aliases resolve per provider: on the Anthropic API `opus` is Opus 5 and
-`sonnet` is Sonnet 5, but on Microsoft Foundry `opus` is Opus 4.6. The tier is
-a statement about *capability class*, not about a specific model.
+It does **not** mean the plugin follows model releases on its own, and this
+guide used to say it did. The models overview is explicit: *"Every Claude model
+ID is a pinned snapshot, including the dateless IDs used from the 4.6
+generation on"*, and *"For models before the 4.6 generation, the alias is a
+convenience pointer that resolves to the dated ID. Dateless IDs are their own
+pinned snapshot; the alias row repeats them"*
+([models overview](https://platform.claude.com/docs/en/about-claude/models/overview)).
+So `claude-opus-5` will not become the successor to Opus 5 by itself. Moving a
+tier to a newer model is an edit, and it belongs in a release.
+
+What an alias does still buy: the tier is a statement about *capability class*
+rather than a specific model, and it resolves per provider. On the Claude API
+`opus` is Opus 5 and `sonnet` is Sonnet 5; a Microsoft Foundry deployment
+resolves by deployment name, which defaults to the Claude API alias.
 
 ### Where Fable 5 fits
 

--- a/hooks/lib/haiku-verify.sh
+++ b/hooks/lib/haiku-verify.sh
@@ -8,6 +8,16 @@
 # another verification.
 # =============================================================================
 
+# The one pinned id in the plugin, and pinned on purpose: this is a machine
+# reading a machine's output, where a model change is a behaviour change nobody
+# asked for. The tiering guide's aliases are for work a human reads.
+#
+# It also carries the nearest retirement date of the current lineup, "not
+# sooner than October 15, 2026"
+# (https://platform.claude.com/docs/en/about-claude/models/overview), so this
+# line is the one to revisit first. `claude-haiku-4-5` is the documented alias
+# and would not move the date: a dateless id from the 4.6 generation on is its
+# own pinned snapshot.
 HAIKU_VERIFY_MODEL="${CRAFTSMAN_VERIFY_MODEL:-claude-haiku-4-5-20251001}"
 
 # haiku_verify <prompt>


### PR DESCRIPTION
A factual error in the plugin's own documentation, in the guide whose subject is choosing a model.

`docs/guides/model-tiering-explained.md` said:

> Aliases resolve to the newest model in their family, so the plugin follows model releases without a version bump.

The [models overview](https://platform.claude.com/docs/en/about-claude/models/overview) says the opposite, in as many words:

> Every Claude model ID is a pinned snapshot, including the dateless IDs used from the 4.6 generation on.

> For models before the 4.6 generation, the alias is a convenience pointer that resolves to the dated ID. Dateless IDs are their own pinned snapshot; the alias row repeats them.

So `claude-opus-5` will not become the successor to Opus 5 on its own. Moving a tier to a newer model is an edit, and it belongs in a release.

What an alias still buys is unchanged and stays in the guide: remappability in one place, and a tier that states a capability class rather than a specific model, resolved per provider.

## The one pinned id

`hooks/lib/haiku-verify.sh` pins `claude-haiku-4-5-20251001`. That is correct and now says why: this is a machine reading a machine's output, where a model change is a behaviour change nobody asked for, unlike the tiers a human reads.

It also carries **the nearest retirement date of the current lineup**, "not sooner than October 15, 2026", which makes it the line to revisit first. Switching it to the documented `claude-haiku-4-5` alias would not move that date, for the reason above.

No deprecated model id anywhere in the repository: no `claude-3-*`, no `claude-instant`, nothing retired.

## Why this one matters more than its size

`CLAUDE.md` sets a rule for this repository: never claim what an AI tool does or does not support without fetching the official documentation, because training data is not authoritative and capabilities change monthly. The guide had broken that rule about the platform it runs on, and it had been read and quoted since.

Found by a platform review that fetched the current documentation instead of trusting the assertion, and verified again before this change was written.
