### PR TITLE
test(perf): the latency ceilings are per execution environment

### DIFF
--- a/.craftsman-baseline.json
+++ b/.craftsman-baseline.json
@@ -226,7 +226,7 @@
 {"complexity":0,"fan_out":3,"file_lines":289,"ignores":3,"max_fn_lines":7,"path":"tests/packs/test-security.sh"},
 {"complexity":0,"fan_out":5,"file_lines":139,"ignores":0,"max_fn_lines":1,"path":"tests/packs/test-structural.sh"},
 {"complexity":0,"fan_out":5,"file_lines":118,"ignores":0,"max_fn_lines":1,"path":"tests/packs/test-symfony.sh"},
-{"complexity":4,"fan_out":2,"file_lines":383,"ignores":0,"max_fn_lines":23,"path":"tests/perf/test-hook-latency.sh","reason":"the latency benchmark (#49)"},
+{"complexity":2,"fan_out":2,"file_lines":396,"ignores":0,"instrument":2,"max_fn_lines":23,"path":"tests/perf/test-hook-latency.sh","reason":"ceilings per execution environment: the hosted macOS runner has its own row"},
 {"complexity":28,"fan_out":1,"file_lines":863,"ignores":1,"instrument":2,"max_fn_lines":129,"path":"tests/run-tests.sh","reason":"tests/ci/test-changed-only.sh registered (#50)"},
 {"complexity":0,"fan_out":0,"file_lines":344,"ignores":0,"max_fn_lines":5,"path":"tests/templates/test-templates.sh"}
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The latency ceilings are per execution environment, not only per
+  operating system.** The Darwin row of `tests/perf/test-hook-latency.sh` was
+  measured on a laptop with 1.4x of room, and the hosted macOS runner ate all
+  of it: the same commit read post-write at 4.0x on the laptop and 5.4x, 5.4x,
+  then 6.3x on three runner instances, bias-detector at 1.5x against 1.6x,
+  1.7x, then 2.5x. The runner's fork basket is cheaper while its interpreter
+  starts are not, by an amount that moves between instances. A `Darwin
+  runner` row (`CI` set) now carries what the runner measured with 1.3x of
+  room over its slowest instance; the laptop row keeps its tighter figures.
+
 - **A write with findings costs one interpreter start for its metrics, not one
   per finding.** `metrics_record_violation` queues its rows while
   `post-write-check.sh` runs and inserts them together on exit through

--- a/tests/perf/test-hook-latency.sh
+++ b/tests/perf/test-hook-latency.sh
@@ -259,20 +259,33 @@ PHPDIRTY
 DIRTY_PAYLOAD="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s"},"cwd":"%s"}' \
     "$PROJECT/src/Dirty.php" "$PROJECT")"
 
-# The ceilings are per operating system, and that is a measured statement
+# The ceilings are per execution environment, and that is a measured statement
 # about what the ratio does and does not absorb. On one machine under load it
 # absorbs 94% of the slowdown, because the basket grows the way the hooks grow.
 # Across operating systems it absorbs nothing: the same commit measured
 # post-write at 3.9x on macOS and 9.5x on an ubuntu runner, where a fork costs
 # half as much (calibration 63ms against 135ms) while the hooks cost about the
-# same, so the hooks' remaining cost there is not made of forks. Two variances,
-# two mechanisms: the ratio for load, a table for the OS. The doubling check
+# same, so the hooks' remaining cost there is not made of forks.
+#
+# Across MACHINES of one operating system it absorbs only part. The Darwin row
+# was measured on a laptop, with 1.4x of room, and the hosted macOS runner ate
+# all of it: the same commit read post-write at 4.0x here and at 5.4x, 5.4x,
+# then 6.3x on three runner instances, bias-detector at 1.5x here and 1.6x,
+# 1.7x, then 2.5x there. The runner's basket is cheaper than the laptop's
+# while its interpreter starts are not, and how much cheaper moves from one
+# instance to the next. So the hosted runner has its own row, taken from what
+# it measured with 1.3x of room over the slowest instance seen, and the laptop
+# row keeps the tighter figures it can hold. Three variances, two mechanisms:
+# the ratio for load, a table for where the test runs. The doubling check
 # further down is the one assertion that transfers unchanged.
-case "$(uname -s)" in
-    Linux)  C_POST=13.5; C_PRE=10.5; C_BIAS=3.7;  C_DIRTY=23 ;;
-    *)      C_POST=5.5;  C_PRE=3.2;  C_BIAS=1.8;  C_DIRTY=13 ;;
+_PERF_ENV="$(uname -s)"
+[[ -n "${CI:-}" ]] && _PERF_ENV="${_PERF_ENV} runner"
+case "$_PERF_ENV" in
+    Linux*)          C_POST=13.5; C_PRE=10.5; C_BIAS=3.7;  C_DIRTY=23 ;;
+    "Darwin runner") C_POST=8.0;  C_PRE=4.5;  C_BIAS=3.2;  C_DIRTY=16 ;;
+    *)               C_POST=5.5;  C_PRE=3.2;  C_BIAS=1.8;  C_DIRTY=13 ;;
 esac
-echo "ceilings for $(uname -s): post-write ${C_POST}x, pre-write ${C_PRE}x, bias ${C_BIAS}x, dirty ${C_DIRTY}x"
+echo "ceilings for ${_PERF_ENV}: post-write ${C_POST}x, pre-write ${C_PRE}x, bias ${C_BIAS}x, dirty ${C_DIRTY}x"
 
 measure_hook "post-write-check.sh" "$C_POST" \
     "cd '$PROJECT' && printf '%s' '$POST_PAYLOAD' | bash '$ROOT_DIR/hooks/post-write-check.sh' >/dev/null 2>&1"


### PR DESCRIPTION
## Why

The macOS leg of CI went red on #59 (a change touching only `.craftsman-baseline.json`) with every hook over its ceiling: post-write 6.25x (ceiling 5.5x), pre-write 3.46x (3.2x), bias-detector 2.46x (1.8x), dirty 16.41x (13x). The Darwin ceilings were measured on a laptop with 1.4x of room, and the hosted macOS runner eats all of it, by an amount that moves from one instance to the next:

| hook | laptop | runner run 1 | run 2 | run 3 (#59) |
|---|---|---|---|---|
| post-write-check.sh | 4.0x | 5.35x | 5.37x | 6.25x |
| bias-detector.sh | 1.5x | 1.58x | 1.70x | 2.46x |

The basket (50 forks + one python3) is cheaper on the runner (98 to 113ms against 146ms) while the hooks' interpreter starts are not, so the ratio absorbs load on one machine and not the gap between two machines of one OS. Same mechanism as the Linux row, one level down.

## What

`tests/perf/test-hook-latency.sh`: a `Darwin runner` row, selected when `CI` is set (GitHub, GitLab and Bitbucket all set it): post-write 8.0x, pre-write 4.5x, bias 3.2x, dirty 16x, each 1.3x over the slowest runner instance seen (dirty estimated after #57, which the runner has not yet measured red). The laptop row keeps 5.5 / 3.2 / 1.8 / 13. The Linux row and the doubling check are unchanged.

A doubling of post-write on the runner (5.4x to 10.8x) still crosses 8x.