### PR TITLE
test(perf): the basket has the hooks' mix, and CI prints the table on every run

### DIFF
--- a/.craftsman-baseline.json
+++ b/.craftsman-baseline.json
@@ -226,7 +226,7 @@
 {"complexity":0,"fan_out":3,"file_lines":289,"ignores":3,"max_fn_lines":7,"path":"tests/packs/test-security.sh"},
 {"complexity":0,"fan_out":5,"file_lines":139,"ignores":0,"max_fn_lines":1,"path":"tests/packs/test-structural.sh"},
 {"complexity":0,"fan_out":5,"file_lines":118,"ignores":0,"max_fn_lines":1,"path":"tests/packs/test-symfony.sh"},
-{"complexity":2,"fan_out":2,"file_lines":409,"ignores":0,"instrument":2,"max_fn_lines":23,"path":"tests/perf/test-hook-latency.sh","reason":"rows set from the runners' first tables under the three-start basket"},
+{"complexity":2,"fan_out":2,"file_lines":411,"ignores":0,"instrument":2,"max_fn_lines":23,"path":"tests/perf/test-hook-latency.sh","reason":"Darwin bias row from the second runner instance"},
 {"complexity":28,"fan_out":1,"file_lines":863,"ignores":1,"instrument":2,"max_fn_lines":129,"path":"tests/run-tests.sh","reason":"tests/ci/test-changed-only.sh registered (#50)"},
 {"complexity":0,"fan_out":0,"file_lines":344,"ignores":0,"max_fn_lines":5,"path":"tests/templates/test-templates.sh"}
 ]

--- a/.craftsman-baseline.json
+++ b/.craftsman-baseline.json
@@ -226,7 +226,7 @@
 {"complexity":0,"fan_out":3,"file_lines":289,"ignores":3,"max_fn_lines":7,"path":"tests/packs/test-security.sh"},
 {"complexity":0,"fan_out":5,"file_lines":139,"ignores":0,"max_fn_lines":1,"path":"tests/packs/test-structural.sh"},
 {"complexity":0,"fan_out":5,"file_lines":118,"ignores":0,"max_fn_lines":1,"path":"tests/packs/test-symfony.sh"},
-{"complexity":2,"fan_out":2,"file_lines":396,"ignores":0,"instrument":2,"max_fn_lines":23,"path":"tests/perf/test-hook-latency.sh","reason":"ceilings per execution environment: the hosted macOS runner has its own row"},
+{"complexity":2,"fan_out":2,"file_lines":406,"ignores":0,"instrument":2,"max_fn_lines":23,"path":"tests/perf/test-hook-latency.sh","reason":"three-start basket, memory named by shape, rows per OS"},
 {"complexity":28,"fan_out":1,"file_lines":863,"ignores":1,"instrument":2,"max_fn_lines":129,"path":"tests/run-tests.sh","reason":"tests/ci/test-changed-only.sh registered (#50)"},
 {"complexity":0,"fan_out":0,"file_lines":344,"ignores":0,"max_fn_lines":5,"path":"tests/templates/test-templates.sh"}
 ]

--- a/.craftsman-baseline.json
+++ b/.craftsman-baseline.json
@@ -226,7 +226,7 @@
 {"complexity":0,"fan_out":3,"file_lines":289,"ignores":3,"max_fn_lines":7,"path":"tests/packs/test-security.sh"},
 {"complexity":0,"fan_out":5,"file_lines":139,"ignores":0,"max_fn_lines":1,"path":"tests/packs/test-structural.sh"},
 {"complexity":0,"fan_out":5,"file_lines":118,"ignores":0,"max_fn_lines":1,"path":"tests/packs/test-symfony.sh"},
-{"complexity":2,"fan_out":2,"file_lines":406,"ignores":0,"instrument":2,"max_fn_lines":23,"path":"tests/perf/test-hook-latency.sh","reason":"three-start basket, memory named by shape, rows per OS"},
+{"complexity":2,"fan_out":2,"file_lines":409,"ignores":0,"instrument":2,"max_fn_lines":23,"path":"tests/perf/test-hook-latency.sh","reason":"rows set from the runners' first tables under the three-start basket"},
 {"complexity":28,"fan_out":1,"file_lines":863,"ignores":1,"instrument":2,"max_fn_lines":129,"path":"tests/run-tests.sh","reason":"tests/ci/test-changed-only.sh registered (#50)"},
 {"complexity":0,"fan_out":0,"file_lines":344,"ignores":0,"max_fn_lines":5,"path":"tests/templates/test-templates.sh"}
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,6 +582,14 @@ jobs:
           chmod +x tests/run-tests.sh
           ./tests/run-tests.sh
 
+      # The latency table, on every run and not only on a red one. The suite
+      # prints a subtest's output on failure alone, so the numbers the ceilings
+      # are set from were only ever readable from a failed job: a row cannot be
+      # tuned from runs that pass.
+      - name: Hook latency report
+        if: always()
+        run: bash tests/perf/test-hook-latency.sh --report
+
   check-agents:
     name: Validate Agent Definitions
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,8 +193,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   above 2.46 and below twice 1.37, which the doubling self-check demands.
   Solving the two runs for the hooks' composition (bias-detector about 44
   forks plus 3 starts, post-write about 168 plus 8) and giving the basket
-  that mix projects the spread at 0.92x to 0.94x. The rows are per operating
-  system again, each about 1.35x over the slowest instance measured, and the
+  that mix read bias-detector at 1.12x on the runner and 1.11x on a laptop.
+  The rows are per operating system again, each about 1.35x over what the
+  basket measured on the runners and the laptop, and the
   calibration memory is named after the basket's shape so an old memory
   cannot declare an idle machine busy. CI prints the latency table on every
   run, not only on a red one, so the rows are tuned from numbers rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,15 +186,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The latency ceilings are per execution environment, not only per
-  operating system.** The Darwin row of `tests/perf/test-hook-latency.sh` was
-  measured on a laptop with 1.4x of room, and the hosted macOS runner ate all
-  of it: the same commit read post-write at 4.0x on the laptop and 5.4x, 5.4x,
-  then 6.3x on three runner instances, bias-detector at 1.5x against 1.6x,
-  1.7x, then 2.5x. The runner's fork basket is cheaper while its interpreter
-  starts are not, by an amount that moves between instances. A `Darwin
-  runner` row (`CI` set) now carries what the runner measured with 1.3x of
-  room over its slowest instance; the laptop row keeps its tighter figures.
+- **The latency basket has the hooks' mix: fifty forks and three interpreter
+  starts.** With one start it read the same commit at 1.37x and 2.46x for
+  bias-detector on two hosted macOS runner instances whose fork cost differed
+  2.2x while an interpreter start cost about the same, and no ceiling can sit
+  above 2.46 and below twice 1.37, which the doubling self-check demands.
+  Solving the two runs for the hooks' composition (bias-detector about 44
+  forks plus 3 starts, post-write about 168 plus 8) and giving the basket
+  that mix projects the spread at 0.92x to 0.94x. The rows are per operating
+  system again, each about 1.35x over the slowest instance measured, and the
+  calibration memory is named after the basket's shape so an old memory
+  cannot declare an idle machine busy. CI prints the latency table on every
+  run, not only on a red one, so the rows are tuned from numbers rather than
+  from failures.
 
 - **A write with findings costs one interpreter start for its metrics, not one
   per finding.** `metrics_record_violation` queues its rows while

--- a/tests/perf/test-hook-latency.sh
+++ b/tests/perf/test-hook-latency.sh
@@ -287,13 +287,16 @@ DIRTY_PAYLOAD="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s"},"c
 # the OS. The doubling check further down is the one assertion that transfers
 # unchanged.
 #
-# The rows carry about 1.35x of room over the slowest instance measured, and
-# each is below twice the fastest measurement of its tightest hook, which is
-# what lets the doubling check hold on every instance.
+# The rows carry about 1.35x of room over what was measured with this basket
+# (ubuntu runner: 7.11x, 5.38x, 1.96x, 10.39x; macOS runner: 4.04x, 1.83x,
+# 1.12x, 10.08x; this laptop: 3.02x, 1.60x, 1.11x, 6.68x), and each is below
+# twice the fastest measurement of its tightest hook, which is what lets the
+# doubling check hold on every instance. CI prints the table on every run:
+# tune a row from those numbers, never from a failure alone.
 _PERF_ENV="$(uname -s)"
 case "$_PERF_ENV" in
-    Linux)  C_POST=6.5;  C_PRE=4.0;  C_BIAS=1.9;  C_DIRTY=14 ;;
-    *)      C_POST=4.2;  C_PRE=2.2;  C_BIAS=1.5;  C_DIRTY=9.5 ;;
+    Linux)  C_POST=9.5;  C_PRE=7.3;  C_BIAS=2.65; C_DIRTY=14 ;;
+    *)      C_POST=5.5;  C_PRE=2.5;  C_BIAS=1.5;  C_DIRTY=13.5 ;;
 esac
 echo "ceilings for ${_PERF_ENV}: post-write ${C_POST}x, pre-write ${C_PRE}x, bias ${C_BIAS}x, dirty ${C_DIRTY}x"
 

--- a/tests/perf/test-hook-latency.sh
+++ b/tests/perf/test-hook-latency.sh
@@ -288,15 +288,17 @@ DIRTY_PAYLOAD="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s"},"c
 # unchanged.
 #
 # The rows carry about 1.35x of room over what was measured with this basket
-# (ubuntu runner: 7.11x, 5.38x, 1.96x, 10.39x; macOS runner: 4.04x, 1.83x,
-# 1.12x, 10.08x; this laptop: 3.02x, 1.60x, 1.11x, 6.68x), and each is below
+# (ubuntu runner, two runs: 7.11x, 5.38x, 1.96x, 10.39x then 7.11x, 5.22x,
+# 1.88x, 10.37x; macOS runner, two instances: 4.04x, 1.83x, 1.12x, 10.08x
+# then 3.87x, 1.85x, 1.32x, 8.62x; this laptop: 3.02x, 1.60x, 1.11x, 6.68x),
+# and each is below
 # twice the fastest measurement of its tightest hook, which is what lets the
 # doubling check hold on every instance. CI prints the table on every run:
 # tune a row from those numbers, never from a failure alone.
 _PERF_ENV="$(uname -s)"
 case "$_PERF_ENV" in
     Linux)  C_POST=9.5;  C_PRE=7.3;  C_BIAS=2.65; C_DIRTY=14 ;;
-    *)      C_POST=5.5;  C_PRE=2.5;  C_BIAS=1.5;  C_DIRTY=13.5 ;;
+    *)      C_POST=5.5;  C_PRE=2.5;  C_BIAS=1.8;  C_DIRTY=13.5 ;;
 esac
 echo "ceilings for ${_PERF_ENV}: post-write ${C_POST}x, pre-write ${C_PRE}x, bias ${C_BIAS}x, dirty ${C_DIRTY}x"
 

--- a/tests/perf/test-hook-latency.sh
+++ b/tests/perf/test-hook-latency.sh
@@ -132,8 +132,19 @@ _is_measurement() {
 # grows the way the hooks grow because it is made of the same thing they are
 # made of, which makes the ratio invariant to load by construction rather than
 # by hope.
+# Fifty forks and THREE interpreter starts, not one. Measured on two hosted
+# macOS runner instances whose fork cost differed 2.2x (basket 98ms against
+# 165ms) while an interpreter start cost about the same on both: solving the
+# two runs for the hooks' composition put bias-detector.sh at about 44 forks
+# plus 3 python3 starts and post-write-check.sh at about 168 plus 8. With one
+# start in the basket the same commit read bias at 1.37x on one instance and
+# 2.46x on the other, and no ceiling can be both above 2.46 and below twice
+# 1.37, which is what the doubling check demands. With three, the projected
+# spread is 0.92x to 0.94x: the basket has the hooks' mix, so what moves the
+# hooks moves it too.
 CALIBRATION_FORKS=50
-CALIBRATION_WORKLOAD="for _ in \$(seq 1 $CALIBRATION_FORKS); do /bin/echo x >/dev/null; done; python3 -c pass; cat '$PROJECT/src/A.php' >/dev/null"
+CALIBRATION_PYTHON_STARTS=3
+CALIBRATION_WORKLOAD="for _ in \$(seq 1 $CALIBRATION_FORKS); do /bin/echo x >/dev/null; done; for _ in \$(seq 1 $CALIBRATION_PYTHON_STARTS); do python3 -c pass; done; cat '$PROJECT/src/A.php' >/dev/null"
 
 FLOOR_MS="$(_median_ms "$CALIBRATION_WORKLOAD" 7)"
 if ! _is_measurement "$FLOOR_MS"; then
@@ -143,7 +154,7 @@ fi
 [[ "$FLOOR_MS" == "0.0" ]] && FLOOR_MS="1.0"
 
 echo "=== Hook latency ==="
-echo "calibration: ${FLOOR_MS}ms (${CALIBRATION_FORKS} forks + one python3 + one read, fastest of 7)"
+echo "calibration: ${FLOOR_MS}ms (${CALIBRATION_FORKS} forks + ${CALIBRATION_PYTHON_STARTS} python3 starts + one read, fastest of 7)"
 echo ""
 printf '%-26s %11s %12s %10s %9s\n' "hook" "fastest" "median" "x baseline" "ceiling"
 
@@ -189,12 +200,16 @@ CEILING_MS_BACKSTOP=2500
 # suspended, and the suspension is printed.
 # Derived from this machine's own fastest calibration ever recorded, not from a
 # number typed into a file whose thesis is that typed numbers do not travel.
-# 210ms is right for this laptop and wrong for a slow CI container, where an
+# 300ms is right for this laptop and wrong for a slow CI container, where an
 # idle calibration above it would suspend the backstop permanently while the
 # output said "busy": a slow machine and a loaded one would be indistinguishable
 # forever.
-CALIBRATION_FLOOR_FILE="${_PERF_STATE_DIR}/craftsman-perf-calibration"
-CALIBRATION_QUIET_MS=210
+# Named after the basket's shape. A memory taken with the one-start basket
+# (126ms on this laptop) read against the three-start one (200ms) says "busy"
+# on an idle machine forever, and the backstop it arms would never apply
+# again. A new shape starts a new memory.
+CALIBRATION_FLOOR_FILE="${_PERF_STATE_DIR}/craftsman-perf-calibration-${CALIBRATION_FORKS}f${CALIBRATION_PYTHON_STARTS}p"
+CALIBRATION_QUIET_MS=300
 if [[ -f "$CALIBRATION_FLOOR_FILE" ]]; then
     _seen_floor="$(head -1 "$CALIBRATION_FLOOR_FILE" 2>/dev/null)"
     if _is_measurement "${_seen_floor:-}"; then
@@ -259,31 +274,26 @@ PHPDIRTY
 DIRTY_PAYLOAD="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s"},"cwd":"%s"}' \
     "$PROJECT/src/Dirty.php" "$PROJECT")"
 
-# The ceilings are per execution environment, and that is a measured statement
+# The ceilings are per operating system, and that is a measured statement
 # about what the ratio does and does not absorb. On one machine under load it
 # absorbs 94% of the slowdown, because the basket grows the way the hooks grow.
-# Across operating systems it absorbs nothing: the same commit measured
-# post-write at 3.9x on macOS and 9.5x on an ubuntu runner, where a fork costs
-# half as much (calibration 63ms against 135ms) while the hooks cost about the
-# same, so the hooks' remaining cost there is not made of forks.
+# Across operating systems it absorbs less: a fork costs half as much on an
+# ubuntu runner as on a Mac while an interpreter start costs about the same,
+# and the basket carries both in a fixed mix. Across machines of one operating
+# system the three-start basket absorbs the rest: the same commit projected at
+# 0.92x and 0.94x for bias-detector on two macOS runner instances whose fork
+# cost differed 2.2x, where the one-start basket read 1.37x and 2.46x. Two
+# variances, two mechanisms: the ratio for load and for machine, a table for
+# the OS. The doubling check further down is the one assertion that transfers
+# unchanged.
 #
-# Across MACHINES of one operating system it absorbs only part. The Darwin row
-# was measured on a laptop, with 1.4x of room, and the hosted macOS runner ate
-# all of it: the same commit read post-write at 4.0x here and at 5.4x, 5.4x,
-# then 6.3x on three runner instances, bias-detector at 1.5x here and 1.6x,
-# 1.7x, then 2.5x there. The runner's basket is cheaper than the laptop's
-# while its interpreter starts are not, and how much cheaper moves from one
-# instance to the next. So the hosted runner has its own row, taken from what
-# it measured with 1.3x of room over the slowest instance seen, and the laptop
-# row keeps the tighter figures it can hold. Three variances, two mechanisms:
-# the ratio for load, a table for where the test runs. The doubling check
-# further down is the one assertion that transfers unchanged.
+# The rows carry about 1.35x of room over the slowest instance measured, and
+# each is below twice the fastest measurement of its tightest hook, which is
+# what lets the doubling check hold on every instance.
 _PERF_ENV="$(uname -s)"
-[[ -n "${CI:-}" ]] && _PERF_ENV="${_PERF_ENV} runner"
 case "$_PERF_ENV" in
-    Linux*)          C_POST=13.5; C_PRE=10.5; C_BIAS=3.7;  C_DIRTY=23 ;;
-    "Darwin runner") C_POST=8.0;  C_PRE=4.5;  C_BIAS=3.2;  C_DIRTY=16 ;;
-    *)               C_POST=5.5;  C_PRE=3.2;  C_BIAS=1.8;  C_DIRTY=13 ;;
+    Linux)  C_POST=6.5;  C_PRE=4.0;  C_BIAS=1.9;  C_DIRTY=14 ;;
+    *)      C_POST=4.2;  C_PRE=2.2;  C_BIAS=1.5;  C_DIRTY=9.5 ;;
 esac
 echo "ceilings for ${_PERF_ENV}: post-write ${C_POST}x, pre-write ${C_PRE}x, bias ${C_BIAS}x, dirty ${C_DIRTY}x"
 


### PR DESCRIPTION
Follow-up to #62, which did not hold: the `Darwin runner` row passed on the slow instance and failed the doubling self-check on the fast one (#59's next run: bias 1.37x, doubled 3.01x, under the 3.2x ceiling).

## Why the instrument, not the rows

Two hosted macOS instances, same commit, one-start basket:

| | basket | post-write | bias | ratio bias |
|---|---|---|---|---|
| fast instance | 98ms | 527ms | 167ms | 1.70x |
| slow instance | 165ms | 752ms | 226ms | 1.37x |
| slowest seen | 113ms | 708ms | 279ms | 2.46x |

Fork cost differs 2.2x between instances; an interpreter start costs about the same. Solving for the hooks' composition: bias-detector about 44 forks + 3 python3 starts, post-write about 168 + 8. A basket of one start is fork-shaped where the hooks are not, so the ratio moves with the instance. No single ceiling can be above 2.46 and below 2 x 1.37, which the doubling self-check requires.

## What

- Basket: 50 forks + 3 python3 starts + one read. Projected bias on the two instances: 0.94x and 0.92x. Laptop: post-write 3.02x, pre-write 1.60x, bias 1.11x, dirty 6.68x.
- Rows per OS again (provisional, about 1.35x over the slowest instance measured; Linux estimated pending its first table): Darwin 4.2 / 2.2 / 1.5 / 9.5, Linux 6.5 / 4.0 / 1.9 / 14.
- Calibration memory named after the basket shape (`craftsman-perf-calibration-50f3p`): the old memory (126ms) read against the new basket (200ms) declared an idle laptop busy and suspended the backstop for good. Quiet fallback 300ms.
- `.github/workflows/ci.yml`: a `Hook latency report` step after the suite, `if: always()`, so the table is readable on green runs too and the rows can be tuned from numbers rather than from failures.

If this run's tables say a row is off, I tune it in a second commit from the printed numbers.